### PR TITLE
Add ESP-IDF BNO08x component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # HF-BNO08x-ESPIDF
-BNO08x component for ESP-IDF
+
+This repository packages the [HF-BNO08x](https://github.com/N3b3x/HF-BNO08x)
+library as an ESP‑IDF component targeting the ESP32‑C6.  The component lives in
+`components/bno08x` and builds the upstream driver along with a simple I²C
+transport implementation.
+
+The upstream project provides a full C++ driver and vendor SH‑2 library for the
+BNO08x family of IMUs.  Here it is wrapped for easy use within any ESP‑IDF
+application.
+
+See `components/bno08x/README.md` for configuration options and an example of
+using the driver in your project.

--- a/components/bno08x/CMakeLists.txt
+++ b/components/bno08x/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(BNO08X_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../HF-BNO08x)
+set(SH2_ROOT ${BNO08X_ROOT}/src/sh2)
+
+set(SRCS
+    ${BNO08X_ROOT}/src/BNO085.cpp
+    ${SH2_ROOT}/euler.c
+    ${SH2_ROOT}/sh2.c
+    ${SH2_ROOT}/sh2_SensorValue.c
+    ${SH2_ROOT}/sh2_util.c
+    ${SH2_ROOT}/shtp.c
+    esp_i2c_transport.cpp
+)
+
+idf_component_register(SRCS ${SRCS}
+                       INCLUDE_DIRS include ${BNO08X_ROOT}/src ${SH2_ROOT}
+                       REQUIRES driver)

--- a/components/bno08x/Kconfig
+++ b/components/bno08x/Kconfig
@@ -1,0 +1,40 @@
+menuconfig BNO08X
+    bool "BNO08x IMU driver"
+    default y
+    help
+        Enable the BNO08x IMU component using the I2C transport on ESP-IDF.
+
+if BNO08X
+
+config BNO08X_I2C_PORT
+    int "I2C port"
+    range 0 1
+    default 0
+    help
+        Select which I2C controller to use.
+
+config BNO08X_I2C_SDA
+    int "SDA GPIO"
+    default 5
+
+config BNO08X_I2C_SCL
+    int "SCL GPIO"
+    default 4
+
+config BNO08X_I2C_FREQ_HZ
+    int "I2C clock speed"
+    default 400000
+    help
+        Frequency for I2C transfers.
+
+config BNO08X_I2C_ADDR
+    hex "BNO08x I2C address"
+    default 0x4A
+    help
+        7-bit address (0x4A or 0x4B depending on ADR pin).
+
+config BNO08X_I2C_TIMEOUT_MS
+    int "I2C timeout (ms)"
+    default 50
+
+endif

--- a/components/bno08x/Kconfig.projbuild
+++ b/components/bno08x/Kconfig.projbuild
@@ -1,0 +1,1 @@
+source "Kconfig"

--- a/components/bno08x/README.md
+++ b/components/bno08x/README.md
@@ -1,0 +1,74 @@
+# BNO08x ESP-IDF Component
+
+This component packages the [HF-BNO08x](https://github.com/N3b3x/HF-BNO08x) driver
+as an ESP‑IDF component for the ESP32‑C6.  Only the I²C transport is provided by
+default.  The underlying driver is hardware agnostic C++ code accompanied by the
+vendor SH-2 library.
+
+## Features
+
+- Complete access to all BNO08x sensor reports
+- Lightweight C++11 implementation with no threads
+- Automatic recovery from sensor resets
+- Optional callback based event handling
+- Simple I²C transport implementation for ESP‑IDF
+
+## Configuration
+
+The component exposes several Kconfig options under `BNO08X`:
+
+- **I2C port** (`BNO08X_I2C_PORT`) – controller number (0 or 1)
+- **SDA GPIO** (`BNO08X_I2C_SDA`) – pin used for SDA
+- **SCL GPIO** (`BNO08X_I2C_SCL`) – pin used for SCL
+- **I2C clock speed** (`BNO08X_I2C_FREQ_HZ`) – default 400 kHz
+- **Device address** (`BNO08X_I2C_ADDR`) – 0x4A or 0x4B depending on the ADR pin
+- **Timeout** (`BNO08X_I2C_TIMEOUT_MS`) – I²C transaction timeout
+
+Adjust these in `menuconfig` to match your hardware wiring.
+
+## Usage
+
+Include the transport header and create an instance:
+
+```cpp
+#include "bno08x_i2c_transport.hpp"
+#include "BNO085.hpp"
+
+BNO08xI2CTransport transport;        // uses Kconfig defaults
+BNO085 imu(&transport);
+
+void app_main(void)
+{
+    if (!imu.begin()) {
+        printf("BNO08x not found\n");
+        return;
+    }
+    imu.enableSensor(BNO085Sensor::RotationVector, 10); // 100 Hz
+    while (true) {
+        imu.update();
+        if (imu.hasNewData(BNO085Sensor::RotationVector)) {
+            auto event = imu.getLatest(BNO085Sensor::RotationVector);
+            printf("Yaw %.1f\n", event.toEuler().yaw);
+        }
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+}
+```
+
+The driver and SH‑2 sources are compiled directly from the `HF-BNO08x`
+submodule, so you benefit from all upstream updates.
+
+## Repository Structure
+
+```
+components/
+└── bno08x/
+    ├── include/                # public API for transport
+    ├── CMakeLists.txt          # builds the driver and SH‑2 library
+    ├── Kconfig / Kconfig.projbuild
+    └── README.md               # this document
+HF-BNO08x/                      # upstream submodule with library code
+```
+
+Refer to the upstream README for an in‑depth description of the driver
+architecture and capabilities.

--- a/components/bno08x/esp_i2c_transport.cpp
+++ b/components/bno08x/esp_i2c_transport.cpp
@@ -1,0 +1,45 @@
+#include "bno08x_i2c_transport.hpp"
+
+BNO08xI2CTransport::BNO08xI2CTransport(i2c_port_t port, gpio_num_t sda,
+                                       gpio_num_t scl, uint8_t addr)
+    : port_(port), sda_(sda), scl_(scl), addr_(addr) {}
+
+bool BNO08xI2CTransport::open() {
+    if (opened_)
+        return true;
+    i2c_config_t conf = {};
+    conf.mode = I2C_MODE_MASTER;
+    conf.sda_io_num = sda_;
+    conf.scl_io_num = scl_;
+    conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
+    conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
+    conf.master.clk_speed = CONFIG_BNO08X_I2C_FREQ_HZ;
+    esp_err_t err = i2c_param_config(port_, &conf);
+    if (err != ESP_OK)
+        return false;
+    err = i2c_driver_install(port_, conf.mode, 0, 0, 0);
+    if (err == ESP_OK)
+        opened_ = true;
+    return err == ESP_OK;
+}
+
+void BNO08xI2CTransport::close() {
+    if (opened_) {
+        i2c_driver_delete(port_);
+        opened_ = false;
+    }
+}
+
+int BNO08xI2CTransport::write(const uint8_t *data, uint32_t length) {
+    esp_err_t err = i2c_master_write_to_device(
+        port_, addr_, data, length,
+        CONFIG_BNO08X_I2C_TIMEOUT_MS / portTICK_PERIOD_MS);
+    return err == ESP_OK ? (int)length : -1;
+}
+
+int BNO08xI2CTransport::read(uint8_t *data, uint32_t length) {
+    esp_err_t err = i2c_master_read_from_device(
+        port_, addr_, data, length,
+        CONFIG_BNO08X_I2C_TIMEOUT_MS / portTICK_PERIOD_MS);
+    return err == ESP_OK ? (int)length : -1;
+}

--- a/components/bno08x/include/bno08x_i2c_transport.hpp
+++ b/components/bno08x/include/bno08x_i2c_transport.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include "BNO085_Transport.hpp"
+#include "driver/i2c.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_timer.h"
+
+/**
+ * @brief IBNO085Transport implementation using ESP-IDF I2C driver.
+ */
+class BNO08xI2CTransport : public IBNO085Transport {
+public:
+    explicit BNO08xI2CTransport(i2c_port_t port = (i2c_port_t)CONFIG_BNO08X_I2C_PORT,
+                                 gpio_num_t sda = (gpio_num_t)CONFIG_BNO08X_I2C_SDA,
+                                 gpio_num_t scl = (gpio_num_t)CONFIG_BNO08X_I2C_SCL,
+                                 uint8_t addr = CONFIG_BNO08X_I2C_ADDR);
+    bool open() override;
+    void close() override;
+    int write(const uint8_t *data, uint32_t length) override;
+    int read(uint8_t *data, uint32_t length) override;
+    bool dataAvailable() override { return true; }
+    void delay(uint32_t ms) override { vTaskDelay(pdMS_TO_TICKS(ms)); }
+    uint32_t getTimeUs() override { return (uint32_t)esp_timer_get_time(); }
+
+private:
+    i2c_port_t port_;
+    gpio_num_t sda_;
+    gpio_num_t scl_;
+    uint8_t addr_;
+    bool opened_{false};
+};


### PR DESCRIPTION
## Summary
- wrap the HF-BNO08x library as a component under `components/bno08x`
- implement an ESP-IDF I2C transport
- provide Kconfig options for I2C bus settings
- document usage in new component README
- update top-level README

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840933602bc8328b62171cd20e764f6